### PR TITLE
fix(safari): Fix safari closing window before print

### DIFF
--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -127,7 +127,9 @@ public returnStyleValues() {
           ${styles}
           ${links}
         </head>
-    <body onload="window.print();window.close()">${printContents}</body>
+        <body onload="window.print(); setTimeout(()=>{ window.close(); }, 0)">
+          ${printContents}
+        </body>
       </html>`);
     popupWin.document.close();
   }


### PR DESCRIPTION
Fixed the issue on safari that the newly opened tab is closed even before the print dialog appears
Fixes #49