### PR TITLE
Wait for rendering and ressources

### DIFF
--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -28,6 +28,13 @@ export class NgxPrintDirective {
   @Input() useExistingCss = false;
 
   /**
+   * A delay in milliseconds to force the print dialog to wait before opened. Default: 0
+   *
+   * @memberof NgxPrintDirective
+   */
+  @Input() printDelay: number = 0;
+
+  /**
    *
    *
    * @memberof NgxPrintDirective
@@ -135,7 +142,7 @@ public returnStyleValues() {
               setTimeout(() => {
                 window.print();
                 setTimeout(() => window.close(), 0);
-              }, 0);
+              }, ${this.printDelay});
             }
             window.addEventListener('load', triggerPrint, false);
           </script>

--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -131,11 +131,13 @@ public returnStyleValues() {
           ${printContents}
           <script defer>
             function triggerPrint(event) {
-              document.removeEventListener('DOMContentLoaded', triggerPrint, false);
-              window.print();
-              setTimeout(()=>{ window.close(); }, 0);
+              window.removeEventListener('load', triggerPrint, false);
+              setTimeout(() => {
+                window.print();
+                setTimeout(() => window.close(), 0);
+              }, 0);
             }
-            document.addEventListener('DOMContentLoaded', triggerPrint, false);
+            window.addEventListener('load', triggerPrint, false);
           </script>
         </body>
       </html>`);

--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -127,8 +127,16 @@ public returnStyleValues() {
           ${styles}
           ${links}
         </head>
-        <body onload="window.print(); setTimeout(()=>{ window.close(); }, 0)">
+        <body>
           ${printContents}
+          <script defer>
+            function triggerPrint(event) {
+              document.removeEventListener('DOMContentLoaded', triggerPrint, false);
+              window.print();
+              setTimeout(()=>{ window.close(); }, 0);
+            }
+            document.addEventListener('DOMContentLoaded', triggerPrint, false);
+          </script>
         </body>
       </html>`);
     popupWin.document.close();


### PR DESCRIPTION
I made some changes to make sure resources are properly loaded and rendering has finished.

1. I used a `defer` attribute in the script tag and paced it at the end of the content. Just to make sure the script runs a bit later.
2. I switched to the event listener API and also unregistered the event.
3. I surrounded the `window.print()` and `window.close()` code with another `setTimeout()` with a default delay of `0`;
4. I added a `printDelay` attribute to the directive API, so users are able to add more delay to the opening of the print dialog to make sure resource loading has finished, etc.

In most cases the default delay of `0` should be fine. With the `setTimeout()` alone, the print dialog will be opened after rendering finished. In the rare cases where this is not enough, a manual delay can be applied. (Not awesome but it really helps, e.g. for webfonts, etc. to wait 100-200ms. The user doesn't really care.)
