### PR TITLE
Fix for the print window closing in FF

### DIFF
--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -157,7 +157,7 @@ public returnStyleValues() {
               }, ${this.printDelay});
             }
             function closeWindow(){
-                window.close(); 
+                window.close();
             }
             window.addEventListener('load', triggerPrint, false);
           </script>

--- a/src/lib/ngx-print.directive.ts
+++ b/src/lib/ngx-print.directive.ts
@@ -153,9 +153,11 @@ public returnStyleValues() {
             function triggerPrint(event) {
               window.removeEventListener('load', triggerPrint, false);
               setTimeout(function() {
-                window.print();
-                setTimeout(function() { window.close(); }, 0);
+                closeWindow(window.print());
               }, ${this.printDelay});
+            }
+            function closeWindow(){
+                window.close(); 
             }
             window.addEventListener('load', triggerPrint, false);
           </script>


### PR DESCRIPTION
When the popup window with print options appeared in FF 82.0.2 and the user chose Microsoft print to PDF then the popup window and print window were both immediately closed without the possibility to save content to pdf file. Solutions with bigger timeout or using handler for the event "onafterprint" (https://stackoverflow.com/questions/18325025/how-to-detect-window-print-finish) were not working in the mentioned firefox version.
This solution is working for at least Chrome Version 86.0.4240.111, FF 82.0.2, Edge 86.0.622.56